### PR TITLE
Introduce recording functionality for sniffer handling

### DIFF
--- a/sniffer/app.py
+++ b/sniffer/app.py
@@ -96,13 +96,13 @@ def read():
     source_ip = request.args.get('source_ip')
     destination_host = request.args.get('destination_host')
 
-    # Get the sniffer, if exists, else return status 404
-    try:
-        sniffer = sniffers[(source_ip, destination_host)]
-    except KeyError:
+    # Get the sniffer, if exists and recording, else return status 404
+    if (source_ip, destination_host) not in sniffers or not sniffers[(source_ip, destination_host)].is_recording():
         msg = '(get_sniff) 404 Not Found: Sniffer (source_ip : {}, destination_host: {})'.format(source_ip, destination_host)
         logger.warning(msg)
         return msg, 404
+    else:
+        sniffer = sniffers[(source_ip, destination_host)]
 
     # Use the sniffer's get_capture() method to get the captured packets
     try:
@@ -138,17 +138,17 @@ def delete():
     logger.debug('Deleting sniffer (source_ip : {}, destination_host: {})...'.format(source_ip, destination_host))
 
     # Get the sniffer object and its source_ip and destination_host, if exists
-    try:
-        sniffer = sniffers[(source_ip, destination_host)]
-    except KeyError:
-        msg = '(get_sniff) 404 Not found: Sniffer (source_ip : {}, destination_host: {})'.format(source_ip, destination_host)
+    if (source_ip, destination_host) not in sniffers or not sniffers[(source_ip, destination_host)].is_recording():
+        msg = '(delete) 404 Not Found: Sniffer (source_ip : {}, destination_host: {})'.format(source_ip, destination_host)
         logger.warning(msg)
         return msg, 404
+    else:
+        sniffer = sniffers[(source_ip, destination_host)]
 
     # Stop the sniffer capture
     sniffer.stop()
 
-    msg = '(get_sniff) Sniffer (source_ip : {}, destination_host: {}) was deleted.'.format(source_ip, destination_host)
+    msg = '(delete) Sniffer (source_ip : {}, destination_host: {}) was deleted.'.format(source_ip, destination_host)
     logger.debug(msg)
 
     return msg, 200

--- a/sniffer/sniffer.py
+++ b/sniffer/sniffer.py
@@ -3,7 +3,7 @@ import logging
 import binascii
 import socket
 import collections
-from scapy.all import sniff, Raw, IP, TCP, send
+from scapy.all import sniff, Raw
 
 logger = logging.getLogger('sniffer')
 
@@ -92,9 +92,6 @@ class Sniffer(threading.Thread):
             prn=lambda pkt: self.process_packet(pkt)
         )
 
-    def filter_packet(self, pkt):
-        return not self.is_alive()
-
     def process_packet(self, pkt):
         if self._recording:
             # Check for retransmission of same packet
@@ -110,10 +107,6 @@ class Sniffer(threading.Thread):
 
             self.port_streams[pkt.dport].append(pkt)
 
-    def is_alive(self):
-        # Return if thread is dead or alive
-        return self.status
-
     def get_capture(self):
         # Get the data that were captured so far
         capture = self.parse_capture()
@@ -124,14 +117,6 @@ class Sniffer(threading.Thread):
         # Stop recording whatever you listen and erase your memory
         self._recording = False
         self.port_streams = collections.defaultdict(lambda: [])
-
-    def stop_packet(self):
-        '''
-        Send a dummy TCP packet to the victim with source IP the destination host's,
-        which will be caught by sniff filter and cause sniff function to stop.
-        '''
-        dummy_packet = IP(dst=self.destination_ip, src=self.source_ip)/TCP(dport=self.destination_port)
-        send(dummy_packet, verbose=0)
 
     def is_recording(self):
         return self._recording

--- a/sniffer/sniffer.py
+++ b/sniffer/sniffer.py
@@ -78,11 +78,15 @@ class Sniffer(threading.Thread):
 
         # Thread has not come to life yet
         self.status = False
+        self._recording = False
 
     def run(self):
         self.status = True
 
         self.start_sniffing()
+
+    def record_sniffing(self):
+        self._recording = True
 
     def start_sniffing(self):
         # Capture only response packets
@@ -134,6 +138,8 @@ class Sniffer(threading.Thread):
         # Send 3 stop packets, in case one is not captured
         for i in range(3):
             self.stop_packet()
+        self._recording = False
+        self.port_streams = collections.defaultdict(lambda: [])
 
     def stop_packet(self):
         '''
@@ -142,6 +148,9 @@ class Sniffer(threading.Thread):
         '''
         dummy_packet = IP(dst=self.destination_ip, src=self.source_ip)/TCP(dport=self.destination_port)
         send(dummy_packet, verbose=0)
+
+    def is_recording(self):
+        return self._recording
 
     def follow_stream(self, stream):
         stream_data = b''

--- a/sniffer/test_sniff.py
+++ b/sniffer/test_sniff.py
@@ -25,19 +25,18 @@ class BaseTestCase(ThreadAwareTestCase):
             calibration_wait=self.calibration_wait
         )
 
-    def _request(self, url):
+    @patch('app.Sniffer.start', return_value=None)
+    def _request(self, url, patched_sniffer_start):
         return self.app.post(
             url,
             data=json.dumps(self.data),
             content_type='application/json'
         )
 
-    @patch('app.Sniffer.start_sniffing', return_value=None)
-    def _start(self, patched_start_sniffing):
+    def _start(self):
         return self._request('/start')
 
-    @patch('sniffer.Sniffer.stop', return_value=None)
-    def _delete(self, patched_sniffer_stop):
+    def _delete(self):
         return self._request('/delete')
 
     def _read(self):


### PR DESCRIPTION
Till now a Sniffer thread was generated for each "start" API call and was
killed during the respective "stop" call.

This PR changes this by reusing sniffer threads. A sniffer thread is created
once and is assigned a 'recording' variable, that represents whether the
thread is recording the captured packets or not. It changes the Sniffer API
by introducing new calls: record_sniffing(): set the sniffer thread to recording
mode, is_recording: get the recording status of the sniffer thread.

The app now is agnostic on the Sniffer object implementation and just needs to
create the sniffer object and call its start() function once at the beginning.
After that it can start the recording by calling record_sniffing() and stop the
recording by calling stop().